### PR TITLE
fixes 'ReferenceError: encode is not defined' error

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -69,7 +69,7 @@ BmpEncoder.prototype.encode = function() {
 	return tempBuffer;
 };
 
-var encode = function(imgData, quality) {
+module.exports = function(imgData, quality) {
   if (typeof quality === 'undefined') quality = 100;
  	var encoder = new BmpEncoder(imgData);
 	var data = encoder.encode();
@@ -79,5 +79,3 @@ var encode = function(imgData, quality) {
     height: imgData.height
   };
 };
-
-module.exports = encode;


### PR DESCRIPTION
when using babel and strict mode, this file gets re-written in an invalid way that causes a reference error:

```
my_project/node_modules/bmp-js/lib/encoder.js:75
module.exports = encode = function(imgData, quality) {
ReferenceError: encode is not defined
```

By removing the `var encode` declaration and just exporting the function directly, the error is resolved.