### PR TITLE
Encoding: option for 24bpp input support (fixes #9) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var bmpData = bmp.decode(bmpBuffer);
 ###Encode RGB
 ```js
 var bmp = require("bmp-js");
-//bmpData={data:Buffer,width:Number,height:Height}
+//bmpData={data:Buffer,rgb:Boolean=false,width:Number,height:Height} default RGBA (4 bytes per pixel in input)
 var rawData = bmp.encode(bmpData);//default no compression
 
 ```

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -8,6 +8,7 @@
 
 function BmpEncoder(imgData){
 	this.buffer = imgData.data;
+	this.bufferAlpha = !(imgData.rgb === true);
 	this.width = imgData.width;
 	this.height = imgData.height;
 	this.extraBytes = this.width%4;
@@ -58,7 +59,9 @@ BmpEncoder.prototype.encode = function() {
 			tempBuffer[p+2]= this.buffer[i++];//r
 			tempBuffer[p+1] = this.buffer[i++];//g
 			tempBuffer[p]  = this.buffer[i++];//b
-			i++;
+			if (this.bufferAlpha){
+				i++;
+			}
 		}
 		if(this.extraBytes>0){
 			var fillOffset = this.pos+y*rowBytes+this.width*3;


### PR DESCRIPTION
There are several kinds of possible input formats for the encoding. However, non-8bpc colors would require an overhaul to the BMP header writing.

I briefly considered an implementation that would automatically derive from the input buffer size and image dimensions the presence of the fourth byte; and throw an error if the dimensions and size are incompatible. While the added safety would probably have been a good thing for many users, I guess there might be some funkier uses of buffers which would break. Plus, the parameter at least makes it clear what is supported.

So, here is the ”put new functionality behind a flag” approach to avoid changing anything for past users.