### PR TITLE
no paddings were necessary in the case of bit32

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -264,8 +264,6 @@ BmpDecoder.prototype.bit32 = function() {
       this.data[location + 2] = green;
       this.data[location + 3] = blue;
     }
-    //skip extra bytes
-    this.pos += (this.width % 4);
   }
 
 };


### PR DESCRIPTION
Hi. Thank you for your nice library.

I got RangeError when I decoded 32bit BMP with a width that is not a multiple of 4.
I think that no paddings are necessary in the case of bit32 decoder since the specification of BMP requires just a multiple of 4 **bytes** per row, does not requires a multiple of 4 **pixels** per row.
