### PR TITLE
Some improvements in the handling of headers and 16-/24-/32-bit data

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -5,26 +5,66 @@
  *
  */
 
-function BmpDecoder(buffer,is_with_alpha) {
-  this.pos = 0;
+function BmpDecoder(buffer, is_with_alpha, toRGBA) {
   this.buffer = buffer;
   this.is_with_alpha = !!is_with_alpha;
+
+  this.toRGBA = !!toRGBA;
+  this.locRed = this.toRGBA ? 0 : 3;
+  this.locGreen = this.toRGBA ? 1 : 2;
+  this.locBlue = this.toRGBA ? 2 : 1;
+  this.locAlpha = this.toRGBA ? 3 : 0;
+
   this.bottom_up = true;
-  this.flag = this.buffer.toString("utf-8", 0, this.pos += 2);
-  if (this.flag != "BM") throw new Error("Invalid BMP File");
+
   this.parseHeader();
   this.parseRGBA();
 }
 
+const BITMAPINFOHEADER = 40
+const BITMAPV2INFOHEADER = 52;
+const BITMAPV3INFOHEADER = 56;
+const BITMAPV4HEADER = 108;
+const BITMAPV5HEADER = 124;
+
+const VALID_TYPES = [
+  BITMAPINFOHEADER,
+  BITMAPV2INFOHEADER,
+  BITMAPV3INFOHEADER,
+  BITMAPV4HEADER,
+  BITMAPV5HEADER,
+];
+
+const BI_RLE8 = 1;
+const BI_RLE4 = 2;
+const BI_BITFIELDS = 3;
+const BI_ALPHABITFIELDS = 6;
+
 BmpDecoder.prototype.parseHeader = function() {
+  this.flag = this.buffer.toString("utf-8", 0, 2);
+
+  if (this.flag !== "BM") throw new Error("Invalid BMP File");
+
+  this.pos = 2;
   this.fileSize = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
-  this.reserved = this.buffer.readUInt32LE(this.pos);
-  this.pos += 4;
+  this.reserved1 = this.buffer.readUInt16LE(this.pos);
+  this.pos += 2;
+  this.reserved2 = this.buffer.readUInt16LE(this.pos);
+  this.pos += 2;
   this.offset = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
+
+  // End of BITMAPFILEHEADER
+
   this.headerSize = this.buffer.readUInt32LE(this.pos);
+  this.type = this.headerSize;
   this.pos += 4;
+
+  if (VALID_TYPES.indexOf(this.type) === -1) {
+    throw new Error("Unsupported BMP header size " + this.headerSize);
+  }
+
   this.width = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
   this.height = this.buffer.readInt32LE(this.pos);
@@ -33,7 +73,7 @@ BmpDecoder.prototype.parseHeader = function() {
   this.pos += 2;
   this.bitPP = this.buffer.readUInt16LE(this.pos);
   this.pos += 2;
-  this.compress = this.buffer.readUInt32LE(this.pos);
+  this.compression = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
   this.rawSize = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
@@ -46,10 +86,61 @@ BmpDecoder.prototype.parseHeader = function() {
   this.importantColors = this.buffer.readUInt32LE(this.pos);
   this.pos += 4;
 
-  if(this.bitPP === 16 && this.is_with_alpha){
-    this.bitPP = 15
+  // De facto defaults
+  if (this.bitPP === 32) {
+    this.maskAlpha = 0;
+    this.maskRed   = 0x00FF0000;
+    this.maskGreen = 0x0000FF00;
+    this.maskBlue  = 0x000000FF;
+  } else if (this.bitPP === 16) {
+    this.maskAlpha = 0;
+    this.maskRed   = 0b0111110000000000;
+    this.maskGreen = 0b0000001111100000;
+    this.maskBlue  = 0b0000000000011111;
   }
-  if (this.bitPP < 15) {
+
+  // End of BITMAPINFOHEADER
+
+  if (
+    this.headerSize > BITMAPINFOHEADER ||
+    this.compression === BI_BITFIELDS ||
+    this.compression === BI_ALPHABITFIELDS
+  ) {
+    this.maskRed = this.buffer.readUInt32LE(this.pos);
+    this.pos += 4;
+    this.maskGreen = this.buffer.readUInt32LE(this.pos);
+    this.pos += 4;
+    this.maskBlue = this.buffer.readUInt32LE(this.pos);
+    this.pos += 4;
+  }
+
+  // End of BITMAPV2INFOHEADER
+
+  if (
+    this.headerSize > BITMAPV2INFOHEADER || (
+      this.type === BITMAPINFOHEADER &&
+      this.compression === BI_ALPHABITFIELDS
+    )
+  ) {
+    this.maskAlpha = this.buffer.readUInt32LE(this.pos);
+    this.pos += 4;
+  }
+
+  // End of BITMAPV3INFOHEADER
+
+  if (this.headerSize > BITMAPV3INFOHEADER) {
+    this.pos += BITMAPV4HEADER - BITMAPV3INFOHEADER;
+  }
+
+  // End of BITMAPV4HEADER
+
+  if (this.headerSize > BITMAPV4HEADER) {
+    this.pos += BITMAPV5HEADER - BITMAPV4HEADER;
+  }
+
+  // End of BITMAPV5HEADER  
+
+  if (this.bitPP <= 8 || this.colors > 0) {
     var len = this.colors === 0 ? 1 << this.bitPP : this.colors;
     this.palette = new Array(len);
     for (var i = 0; i < len; i++) {
@@ -65,11 +156,83 @@ BmpDecoder.prototype.parseHeader = function() {
       };
     }
   }
+
+  // End of color table
+
   if(this.height < 0) {
     this.height *= -1;
     this.bottom_up = false;
   }
 
+  // We have these:
+  // 
+  // const sample = 0101 0101 0101 0101
+  // const mask   = 0111 1100 0000 0000
+  // 256        === 0000 0001 0000 0000
+  // 
+  // We want to take the sample and turn it into an 8-bit value.
+  // 
+  // 1. We extract the last bit of the mask:
+  // 
+  // 0000 0100 0000 0000
+  //       ^  
+  // 
+  // Like so:
+  // 
+  // const a = ~mask =    1000 0011 1111 1111
+  // const b = a + 1 =    1000 0100 0000 0000
+  // const c = b & mask = 0000 0100 0000 0000
+  // 
+  // 2. We shift it to the right and extract the bit before the first:
+  // 
+  // 0000 0000 0010 0000
+  //             ^
+  //              
+  // Like so:
+  // 
+  // const d = mask / c = 0000 0000 0001 1111
+  // const e = mask + 1 = 0000 0000 0010 0000
+  // 
+  // 3. We apply the mask and the two values above to a sample:
+  // 
+  // const f = sample & mask = 0101 0100 0000 0000
+  // const g = f / c =         0000 0000 0001 0101
+  // const h = 256 / e =       0000 0000 0000 0100
+  // const i = g * h =         0000 0000 1010 1000
+  //                                     ^^^^ ^
+  //                                     
+  // Voila, we have extracted a sample and "stretched" it to 8 bits. For samples
+  // which are already 8-bit, h === 1 and g === i.
+
+  const maskRedR   = (~this.maskRed   + 1) & this.maskRed;  
+  const maskGreenR = (~this.maskGreen + 1) & this.maskGreen;
+  const maskBlueR  = (~this.maskBlue  + 1) & this.maskBlue; 
+  const maskAlphaR = (~this.maskAlpha + 1) & this.maskAlpha;
+
+  const shiftedMaskRedL   = this.maskRed   / maskRedR   + 1;
+  const shiftedMaskGreenL = this.maskGreen / maskGreenR + 1;
+  const shiftedMaskBlueL  = this.maskBlue  / maskBlueR  + 1;
+  const shiftedMaskAlphaL = this.maskAlpha / maskAlphaR + 1;
+
+  this.shiftRed = function(x) {
+    return (((x & this.maskRed)   / maskRedR)   * 0x100) / shiftedMaskRedL;
+  };
+
+  this.shiftGreen = function(x) {
+    return (((x & this.maskGreen) / maskGreenR) * 0x100) / shiftedMaskGreenL;
+  };
+
+  this.shiftBlue = function(x) {
+    return (((x & this.maskBlue)  / maskBlueR)  * 0x100) / shiftedMaskBlueL;
+  };
+
+  this.shiftAlpha = this.maskAlpha !== 0
+    ? function(x) {
+      return (((x & this.maskAlpha) / maskAlphaR) * 0x100) / shiftedMaskAlphaL;
+    }
+    : function(x) {
+      return 255;
+    };
 }
 
 BmpDecoder.prototype.parseRGBA = function() {
@@ -110,8 +273,7 @@ BmpDecoder.prototype.bit1 = function() {
 };
 
 BmpDecoder.prototype.bit4 = function() {
-    //RLE-4
-    if(this.compress == 2){
+    if (this.compression === BI_RLE4){
         this.data.fill(0xff);
 
         var location = 0;
@@ -231,8 +393,7 @@ BmpDecoder.prototype.bit4 = function() {
 };
 
 BmpDecoder.prototype.bit8 = function() {
-    //RLE-8
-    if(this.compress == 1){
+    if (this.compression === BI_RLE8){
         this.data.fill(0xff);
 
         var location = 0;
@@ -323,163 +484,69 @@ BmpDecoder.prototype.bit8 = function() {
     }
 };
 
-BmpDecoder.prototype.bit15 = function() {
-  var dif_w =this.width % 3;
-  var _11111 = parseInt("11111", 2),_1_5 = _11111;
-  for (var y = this.height - 1; y >= 0; y--) {
-    var line = this.bottom_up ? y : this.height - 1 - y
-    for (var x = 0; x < this.width; x++) {
-
-      var B = this.buffer.readUInt16LE(this.pos);
-      this.pos+=2;
-      var blue = (B & _1_5) / _1_5 * 255 | 0;
-      var green = (B >> 5 & _1_5 ) / _1_5 * 255 | 0;
-      var red = (B >> 10 & _1_5) / _1_5 * 255 | 0;
-      var alpha = (B>>15)?0xFF:0x00;
-
-      var location = line * this.width * 4 + x * 4;
-
-      this.data[location] = alpha;
-      this.data[location + 1] = blue;
-      this.data[location + 2] = green;
-      this.data[location + 3] = red;
-    }
-    //skip extra bytes
-    this.pos += dif_w;
-  }
-};
-
 BmpDecoder.prototype.bit16 = function() {
-  var dif_w =(this.width % 2)*2;
-  //default xrgb555
-  this.maskRed = 0x7C00;
-  this.maskGreen = 0x3E0;
-  this.maskBlue =0x1F;
-  this.mask0 = 0;
+  const data = this.data;
+  const dif_w = (this.width % 2) * 2;
+  for (let y = this.height - 1; y >= 0; y--) {
+    const line = this.bottom_up ? y : this.height - 1 - y;
+    for (let x = 0; x < this.width; x++) {
+      const loc = line * this.width * 4 + x * 4;
+      const px = this.buffer.readUInt16LE(this.pos);
+      this.pos += 2;
 
-  if(this.compress == 3){
-    this.maskRed = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.maskGreen = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.maskBlue = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.mask0 = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-  }
-
-
-  var ns=[0,0,0];
-  for (var i=0;i<16;i++){
-    if ((this.maskRed>>i)&0x01) ns[0]++;
-    if ((this.maskGreen>>i)&0x01) ns[1]++;
-    if ((this.maskBlue>>i)&0x01) ns[2]++;
-  }
-  ns[1]+=ns[0]; ns[2]+=ns[1];	ns[0]=8-ns[0]; ns[1]-=8; ns[2]-=8;
-
-  for (var y = this.height - 1; y >= 0; y--) {
-    var line = this.bottom_up ? y : this.height - 1 - y;
-    for (var x = 0; x < this.width; x++) {
-
-      var B = this.buffer.readUInt16LE(this.pos);
-      this.pos+=2;
-
-      var blue = (B&this.maskBlue)<<ns[0];
-      var green = (B&this.maskGreen)>>ns[1];
-      var red = (B&this.maskRed)>>ns[2];
-
-      var location = line * this.width * 4 + x * 4;
-
-      this.data[location] = 0;
-      this.data[location + 1] = blue;
-      this.data[location + 2] = green;
-      this.data[location + 3] = red;
+      data[loc + this.locRed] = this.shiftRed(px);
+      data[loc + this.locGreen] = this.shiftGreen(px);
+      data[loc + this.locBlue] = this.shiftBlue(px);
+      data[loc + this.locAlpha] = this.shiftAlpha(px);
     }
-    //skip extra bytes
+
+    // Skip extra bytes
     this.pos += dif_w;
   }
 };
 
 BmpDecoder.prototype.bit24 = function() {
-  for (var y = this.height - 1; y >= 0; y--) {
-    var line = this.bottom_up ? y : this.height - 1 - y
-    for (var x = 0; x < this.width; x++) {
-      //Little Endian rgb
-      var blue = this.buffer.readUInt8(this.pos++);
-      var green = this.buffer.readUInt8(this.pos++);
-      var red = this.buffer.readUInt8(this.pos++);
-      var location = line * this.width * 4 + x * 4;
-      this.data[location] = 0;
-      this.data[location + 1] = blue;
-      this.data[location + 2] = green;
-      this.data[location + 3] = red;
+  const data = this.data;
+  for (let y = this.height - 1; y >= 0; y--) {
+    const line = this.bottom_up ? y : this.height - 1 - y
+    for (let x = 0; x < this.width; x++) {
+      const loc = line * this.width * 4 + x * 4;
+      const blue = this.buffer.readUInt8(this.pos++);
+      const green = this.buffer.readUInt8(this.pos++);
+      const red = this.buffer.readUInt8(this.pos++);
+
+      data[loc + this.locRed] = red;
+      data[loc + this.locGreen] = green;
+      data[loc + this.locBlue] = blue;
     }
-    //skip extra bytes
+
+    // Skip extra bytes
     this.pos += (this.width % 4);
   }
-
 };
 
-/**
- * add 32bit decode func
- * @author soubok
- */
 BmpDecoder.prototype.bit32 = function() {
-  //BI_BITFIELDS
-  if(this.compress == 3){
-    this.maskRed = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.maskGreen = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.maskBlue = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-    this.mask0 = this.buffer.readUInt32LE(this.pos);
-    this.pos+=4;
-      for (var y = this.height - 1; y >= 0; y--) {
-          var line = this.bottom_up ? y : this.height - 1 - y;
-          for (var x = 0; x < this.width; x++) {
-              //Little Endian rgba
-              var alpha = this.buffer.readUInt8(this.pos++);
-              var blue = this.buffer.readUInt8(this.pos++);
-              var green = this.buffer.readUInt8(this.pos++);
-              var red = this.buffer.readUInt8(this.pos++);
-              var location = line * this.width * 4 + x * 4;
-              this.data[location] = alpha;
-              this.data[location + 1] = blue;
-              this.data[location + 2] = green;
-              this.data[location + 3] = red;
-          }
-      }
+  const data = this.data;
+  for (let y = this.height - 1; y >= 0; y--) {
+    const line = this.bottom_up ? y : this.height - 1 - y;
+    for (let x = 0; x < this.width; x++) {
+      const loc = line * this.width * 4 + x * 4;
+      const px = this.buffer.readUInt32LE(this.pos);
+      this.pos += 4;
 
-  }else{
-      for (var y = this.height - 1; y >= 0; y--) {
-          var line = this.bottom_up ? y : this.height - 1 - y;
-          for (var x = 0; x < this.width; x++) {
-              //Little Endian argb
-              var blue = this.buffer.readUInt8(this.pos++);
-              var green = this.buffer.readUInt8(this.pos++);
-              var red = this.buffer.readUInt8(this.pos++);
-              var alpha = this.buffer.readUInt8(this.pos++);
-              var location = line * this.width * 4 + x * 4;
-              this.data[location] = alpha;
-              this.data[location + 1] = blue;
-              this.data[location + 2] = green;
-              this.data[location + 3] = red;
-          }
-      }
-
+      data[loc + this.locRed] = this.shiftRed(px);
+      data[loc + this.locGreen] = this.shiftGreen(px);
+      data[loc + this.locBlue] = this.shiftBlue(px);
+      data[loc + this.locAlpha] = this.shiftAlpha(px);
+    }
   }
-
-
-
-
 };
 
 BmpDecoder.prototype.getData = function() {
   return this.data;
 };
 
-module.exports = function(bmpData) {
-  var decoder = new BmpDecoder(bmpData);
+module.exports = function(bmpData, toRGBA) {
+  var decoder = new BmpDecoder(bmpData, false, toRGBA);
   return decoder;
 };

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -194,7 +194,7 @@ BmpDecoder.prototype.parseHeader = function() {
   // 
   // const f = sample & mask = 0101 0100 0000 0000
   // const g = f / c =         0000 0000 0001 0101
-  // const h = 256 / e =       0000 0000 0000 0100
+  // const h = 256 / e =       0000 0000 0000 1000
   // const i = g * h =         0000 0000 1010 1000
   //                                     ^^^^ ^
   //                                     

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -117,10 +117,8 @@ BmpDecoder.prototype.parseHeader = function() {
   // End of BITMAPV2INFOHEADER
 
   if (
-    this.headerSize > BITMAPV2INFOHEADER || (
-      this.type === BITMAPINFOHEADER &&
-      this.compression === BI_ALPHABITFIELDS
-    )
+    this.headerSize > BITMAPV2INFOHEADER ||
+    this.compression === BI_ALPHABITFIELDS
   ) {
     this.maskAlpha = this.buffer.readUInt32LE(this.pos);
     this.pos += 4;

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -5,9 +5,8 @@
  *
  */
 
-function BmpDecoder(buffer, is_with_alpha, toRGBA) {
+function BmpDecoder(buffer, toRGBA) {
   this.buffer = buffer;
-  this.is_with_alpha = !!is_with_alpha;
 
   this.toRGBA = !!toRGBA;
   this.locRed = this.toRGBA ? 0 : 3;
@@ -545,6 +544,6 @@ BmpDecoder.prototype.getData = function() {
 };
 
 module.exports = function(bmpData, toRGBA) {
-  var decoder = new BmpDecoder(bmpData, false, toRGBA);
+  var decoder = new BmpDecoder(bmpData, toRGBA);
   return decoder;
 };


### PR DESCRIPTION
Lots of changes, but most of them are just simplifications.

The major ones are the automation of extra header field detection and more spec-compliance in data parsing. For example, the alpha mask actually isn't included in `BITMAPINFOHEADER` / `BITMAPV2INFOHEADER` headers, unless asked by `BI_ALPHABITFIELDS`, unlike what is assumed in the current `master` (this is what made me fix this library, since I had to deal with images which were crashing because of this). Another improvement is the mask handling, especially so in the 16-bit mode: it's completely universal now, and there's no need in the 15-bit mode anymore, nor in `is_with_alpha`.

Also added a `toRGBA` option, switching the output to big endian RGBA, making it compatible with other libraries, like `pngjs`.

Using the [Wikipedia article](https://en.wikipedia.org/wiki/BMP_file_format) as the specification, for the lack of a better centralized doc.

Currently published as `@jeremejevs/bmp-js`, for those who need this ASAP.