### PR TITLE
fix: fix nodejs DEP0005 'Deprecate: new Buffer()'

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -75,7 +75,7 @@ BmpDecoder.prototype.parseHeader = function() {
 BmpDecoder.prototype.parseRGBA = function() {
     var bitn = "bit" + this.bitPP;
     var len = this.width * this.height * 4;
-    this.data = new Buffer(len);
+    this.data = Buffer.alloc(len);
     this[bitn]();
 };
 

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -30,7 +30,7 @@ function BmpEncoder(imgData){
 }
 
 BmpEncoder.prototype.encode = function() {
-	var tempBuffer = new Buffer(this.offset+this.rgbSize);
+	var tempBuffer = Buffer.alloc(this.offset+this.rgbSize);
 	this.pos = 0;
 	tempBuffer.write(this.flag,this.pos,2);this.pos+=2;
 	tempBuffer.writeUInt32LE(this.fileSize,this.pos);this.pos+=4;


### PR DESCRIPTION
# Fix DeprecationWarning

```
(node:12820) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/