### PR TITLE
Support bottom to top pixel arrangement

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -23,13 +23,13 @@ function BmpEncoder(imgData){
 	this.planes = 1;
 	this.bitPP = 24;
 	this.compress = 0;
-	this.hr = 0;
-	this.vr = 0;
+	this.hr = 72;
+	this.vr = 72;
 	this.colors = 0;
 	this.importantColors = 0;
 }
 
-BmpEncoder.prototype.encode = function() {
+BmpEncoder.prototype.encode = function(bottomTop) {
 	var tempBuffer = new Buffer(this.offset+this.rgbSize);
 	this.pos = 0;
 	tempBuffer.write(this.flag,this.pos,2);this.pos+=2;
@@ -39,7 +39,7 @@ BmpEncoder.prototype.encode = function() {
 
 	tempBuffer.writeUInt32LE(this.headerInfoSize,this.pos);this.pos+=4;
 	tempBuffer.writeUInt32LE(this.width,this.pos);this.pos+=4;
-	tempBuffer.writeInt32LE(-this.height,this.pos);this.pos+=4;
+	tempBuffer.writeInt32LE(bottomTop ? this.height : - this.height,this.pos);this.pos+=4;
 	tempBuffer.writeUInt16LE(this.planes,this.pos);this.pos+=2;
 	tempBuffer.writeUInt16LE(this.bitPP,this.pos);this.pos+=2;
 	tempBuffer.writeUInt32LE(this.compress,this.pos);this.pos+=4;
@@ -52,30 +52,46 @@ BmpEncoder.prototype.encode = function() {
 	var i=0;
 	var rowBytes = 3*this.width+this.extraBytes;
 
-	for (var y = 0; y <this.height; y++){
-		for (var x = 0; x < this.width; x++){
-			var p = this.pos+y*rowBytes+x*3;
-			i++;//a
-			tempBuffer[p]= this.buffer[i++];//b
-			tempBuffer[p+1] = this.buffer[i++];//g
-			tempBuffer[p+2]  = this.buffer[i++];//r
-		}
-		if(this.extraBytes>0){
-			var fillOffset = this.pos+y*rowBytes+this.width*3;
-			tempBuffer.fill(0,fillOffset,fillOffset+this.extraBytes);
+	if(bottomTop){
+		for (var y = this.height-1; y >=0; y--){
+			for (var x = 0; x < this.width; x++){
+				var p = this.pos+y*rowBytes+x*3;
+				i++;//a
+				tempBuffer[p]= this.buffer[i++];//b
+				tempBuffer[p+1] = this.buffer[i++];//g
+				tempBuffer[p+2]  = this.buffer[i++];//r
+			}
+			if(this.extraBytes>0){
+				var fillOffset = this.pos+y*rowBytes+this.width*3;
+				tempBuffer.fill(0,fillOffset,fillOffset+this.extraBytes);
+			}
+		}	
+	
+	}else{
+		for (var y = 0; y <this.height; y++){
+			for (var x = 0; x < this.width; x++){
+				var p = this.pos+y*rowBytes+x*3;
+				i++;//a
+				tempBuffer[p]= this.buffer[i++];//b
+				tempBuffer[p+1] = this.buffer[i++];//g
+				tempBuffer[p+2]  = this.buffer[i++];//r
+			}
+			if(this.extraBytes>0){
+				var fillOffset = this.pos+y*rowBytes+this.width*3;
+				tempBuffer.fill(0,fillOffset,fillOffset+this.extraBytes);
+			}
 		}
 	}
 
 	return tempBuffer;
 };
 
-module.exports = function(imgData, quality) {
-  if (typeof quality === 'undefined') quality = 100;
- 	var encoder = new BmpEncoder(imgData);
-	var data = encoder.encode();
-  return {
-    data: data,
-    width: imgData.width,
-    height: imgData.height
-  };
+module.exports = function(imgData, bottomTop=false) {
+	var encoder = new BmpEncoder(imgData);
+	var data = encoder.encode(bottomTop);
+	return {
+	data: data,
+	width: imgData.width,
+	height: imgData.height
+	};
 };

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -23,8 +23,8 @@ function BmpEncoder(imgData){
 	this.planes = 1;
 	this.bitPP = 24;
 	this.compress = 0;
-	this.hr = 72;
-	this.vr = 72;
+	this.hr = 0;
+	this.vr = 0;
 	this.colors = 0;
 	this.importantColors = 0;
 }


### PR DESCRIPTION
Hi,

I encountered an issue when trying to use an image generated by your encoder with a tool, it turns out it only supported BMP with bottom-top arrangement and positive height on the header.

I just added an argument to be able to select which mode you want to encode in. 

The `encode()` function will work the same as before if you only provide `imageData` and no `bottomTop` argument.

you can use `encode(imageData, true)` to encode with bottomTop approach.

regards
Anil